### PR TITLE
Cope with quotes in file- and module- names

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -51,10 +51,6 @@ def setup_config_variables():
         PathVariable('SEVENZIPPATH', 'Path to 7zip sources', sevenzippath,
                                                         PathVariable.PathIsDir),
         PathVariable('ZLIBPATH', 'Path to zlib install', zlibpath,
-                                                        PathVariable.PathIsDir).
-        PathVariable('ZLIBPATH', 'Path to zlib install', zlibpath,
-                                                        PathVariable.PathIsDir),
-        PathVariable('ZLIBPATH', 'Path to zlib install', zlibpath,
                                                         PathVariable.PathIsDir)
     )
 

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -37,6 +37,7 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QCoreApplication>
+#include <QTextDocument>
 #include <boost/bind.hpp>
 #include <regex>
 
@@ -909,10 +910,10 @@ QString DownloadManager::getDownloadFileName(const QString &baseName) const
 QString DownloadManager::getFileNameFromNetworkReply(QNetworkReply *reply)
 {
   if (reply->hasRawHeader("Content-Disposition")) {
-    std::tr1::regex exp("filename=\"(.*)\"");
+    std::regex exp("filename=\"(.*)\"");
 
-    std::tr1::cmatch result;
-    if (std::tr1::regex_search(reply->rawHeader("Content-Disposition").constData(), result, exp)) {
+    std::cmatch result;
+    if (std::regex_search(reply->rawHeader("Content-Disposition").constData(), result, exp)) {
       return QString::fromUtf8(result.str(1).c_str());
     }
   }
@@ -1128,6 +1129,12 @@ void DownloadManager::nxmFilesAvailable(int, QVariant userData, QVariant resultD
       if (!info->m_FileInfo->version.isValid()) {
         info->m_FileInfo->version = info->m_FileInfo->newestVersion;
       }
+      //Nexus has HTMLd these so unhtml them if necessary
+      QTextDocument doc;
+      doc.setHtml(info->m_FileInfo->modName);
+      info->m_FileInfo->modName = doc.toPlainText();
+      doc.setHtml(info->m_FileInfo->name);
+      info->m_FileInfo->name = doc.toPlainText();
       info->m_FileInfo->fileCategory = convertFileCategory(fileInfo["category_id"].toInt());
       info->m_FileInfo->fileTime = matchDate(fileInfo["date"].toString());
       info->m_FileInfo->fileID = fileInfo["id"].toInt();

--- a/src/nexusinterface.cpp
+++ b/src/nexusinterface.cpp
@@ -196,12 +196,13 @@ void NexusInterface::loginCompleted()
 
 void NexusInterface::interpretNexusFileName(const QString &fileName, QString &modName, int &modID, bool query)
 {
-  static std::tr1::regex exp("^([a-zA-Z0-9_\\- ]*?)([-_ ][VvRr]?[0-9_]+)?-([1-9][0-9]+).*");
-  static std::tr1::regex simpleexp("^([a-zA-Z0-9_]+)");
+  //Look for something along the lines of modulename-Vn-m + any old rubbish.
+  static std::regex exp("^([a-zA-Z0-9_'\"\\- ]*?)([-_ ][VvRr]?[0-9_]+)?-([1-9][0-9]+).*");
+  static std::regex simpleexp("^([a-zA-Z0-9_]+)");
 
   QByteArray fileNameUTF8 = fileName.toUtf8();
-  std::tr1::cmatch result;
-  if (std::tr1::regex_search(fileNameUTF8.constData(), result, exp)) {
+  std::cmatch result;
+  if (std::regex_search(fileNameUTF8.constData(), result, exp)) {
     modName = QString::fromUtf8(result[1].str().c_str());
     modName = modName.replace('_', ' ').trimmed();
 
@@ -231,7 +232,7 @@ void NexusInterface::interpretNexusFileName(const QString &fileName, QString &mo
       modID = strtol(candidate.c_str(), nullptr, 10);
     }
     qDebug("mod id guessed: %s -> %d", qPrintable(fileName), modID);
-  } else if (std::tr1::regex_search(fileNameUTF8.constData(), result, simpleexp)) {
+  } else if (std::regex_search(fileNameUTF8.constData(), result, simpleexp)) {
     qDebug("simple expression matched, using name only");
     modName = QString::fromUtf8(result[1].str().c_str());
     modName = modName.replace('_', ' ').trimmed();


### PR DESCRIPTION
Fixes #324 - un-htmls module names and ignores quotes when trying to determine module id from download filename