### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Here is a complete list:
 * https://github.com/TanninOne/modorganizer-lootcli
 * https://github.com/TanninOne/modorganizer-helper
 * https://github.com/TanninOne/modorganizer-tool_nmmimport
-* https://github.com/TanninOne/modorganizer-tool_pyniedit
+* https://github.com/TanninOne/modorganizer-tool_configurator
 * https://github.com/TanninOne/modorganizer-tool_inieditor
 * https://github.com/TanninOne/modorganizer-preview_base
 * https://github.com/TanninOne/modorganizer-diagnose_basic


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/TanninOne/modorganizer-tool_pyniedit | https://github.com/TanninOne/modorganizer-tool_configurator 
